### PR TITLE
AT-4992 // Corrects Serialization of `claim_status`

### DIFF
--- a/edi_835_parser/transaction_set/transaction_set.py
+++ b/edi_835_parser/transaction_set/transaction_set.py
@@ -116,7 +116,7 @@ class TransactionSet:
 			'provider_prefix': claim.rendering_provider.name_prefix if claim.rendering_provider else None,
 			'claim_received_date': claim.claim_received_date.date if claim.claim_received_date else None,
 			'claim_paid_date': transaction.financial_information.transaction_date,
-			'claim_status': claim.claim.status if claim.claim else None,
+			'claim_status': claim.claim.status.code if claim.claim else None,
 			'claim_total_charge_amount': claim.claim.charge_amount if claim.claim else None,
 			'claim_payment_amount': claim.claim.paid_amount if claim.claim else None,
 			'claim_patient_responsibility': claim.claim.patient_responsibility_amount if claim.claim else None,


### PR DESCRIPTION
Object instead of "value" (`claim_status` code) being passed.


I did not hunt the "why" too hard. But, this inside claim status:

```
def _lookup_status(code: str) -> Status:
	status = [s for s in _REGISTRY if s.code == code]
	if len(status) == 0:
		warn(f'ClaimStatus: Code {code} does not match a status in the edi-835-parser claim status registry.')
		return Status('code', 'uncategorized', PayerClassification.UNKNOWN)

	return status[0]


class ClaimStatus(Element):

	def parser(self, value: str) -> Status:
		return _lookup_status(value)
```

is the issue.