### PR TITLE
Improves reader support to fetch the tax ID from references or from t…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,21 @@ def sample_835():
 
 
 @pytest.fixture
+def sample_835_with_func():
+	def modify_file_content(modify_func=None):
+		path = current_path + '/test_edi_835_files/sample_835.txt'
+		base_content = open(path, 'r').read()
+		if modify_func:
+			content = modify_func(base_content)
+		else:
+			content = base_content
+
+		return edi_835_parser.parse_edi_string(content)
+
+	return modify_file_content
+
+
+@pytest.fixture
 def sample_935_with_interests():
 	path = current_path + '/test_edi_835_files/sample_835_with_interests.txt'
 	return edi_835_parser.parse(path)

--- a/tests/loops/test_transaction.py
+++ b/tests/loops/test_transaction.py
@@ -29,3 +29,25 @@ def test_transaction_reference_identification_number(sample_835):
 def test_transaction_header_number(sample_835):
 	transaction = sample_835.transactions[0]
 	assert transaction.header_number.number == 1
+
+
+def test_payee_identification(sample_835):
+	transaction = sample_835.transactions[0]
+
+	assert transaction.payee_identification.value == '204881619'
+	assert transaction.payee_identification.qualifier_code == 'TJ'
+
+
+def test_payee_indentification_with_tax_id_on_n1(sample_835_with_func):
+	def modify(content):
+		return content.replace(
+			'N1*PE*UNIVERSITY HOSPITALS MEDICAL GROUP INC*XX*1669499414~',
+			'N1*PE*UNIVERSITY HOSPITALS MEDICAL GROUP INC*FI*130871925~',
+		)
+
+	sample_835 = sample_835_with_func(modify)
+	transaction = sample_835.transactions[0]
+
+	assert transaction.payee_identification.value == '130871925'
+	assert transaction.payee_identification.qualifier_code == 'TJ'
+	assert transaction.payee_identification.qualifier == 'federal taxpayer identification number'

--- a/tests/loops/test_transaction.py
+++ b/tests/loops/test_transaction.py
@@ -38,7 +38,7 @@ def test_payee_identification(sample_835):
 	assert transaction.payee_identification.qualifier_code == 'TJ'
 
 
-def test_payee_indentification_with_tax_id_on_n1(sample_835_with_func):
+def test_payee_identification_with_tax_id_on_n1(sample_835_with_func):
 	def modify(content):
 		return content.replace(
 			'N1*PE*UNIVERSITY HOSPITALS MEDICAL GROUP INC*XX*1669499414~',


### PR DESCRIPTION
…he N1 segment


N1 includes the name of the entity, the entity type, and a id / qualifier.

This qualifier can be many different values but can be the federal taxpayer identification number (FI).  Some payers place this in the n1 segment while others add this as a labeled refrence.

This method ensures that a refrence compatible object is returned regardless of where the payer places the tax id with a qualifier of 'federal taxpayer identification number'.

https://www.stedi.com/edi/x12-005010/segment/N1#N1-03


[AT-6173]

[AT-6173]: https://affect-thera.atlassian.net/browse/AT-6173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ